### PR TITLE
reverse changes to imports in embedding_webagg

### DIFF
--- a/examples/user_interfaces/embedding_webagg.py
+++ b/examples/user_interfaces/embedding_webagg.py
@@ -20,7 +20,7 @@ import tornado.ioloop
 import tornado.websocket
 
 
-from backend_webagg_core import (
+from matplotlib.backends.backend_webagg_core import (
     FigureManagerWebAgg, new_figure_manager_given_figure)
 from matplotlib.figure import Figure
 


### PR DESCRIPTION
As describted in #3204 and #3205, changes to `embedding_webagg.py` were not meant to be in this pull request.

I tested this on Windows-7 (x64) and Ubuntu-14.14 in a virtualenv with [`e9c7dcb`](https://github.com/mikofski/matplotlib/commit/e9c7dcb6028492d7dd31a4034f122f6b50ecbfb9) installed by calling:

```
$ python ~/matplotlib/examples/user_interfaces/embedding_webagg.py
```

Prior to the patch running `embedding_webagg.py` raised exceptions, because [`FigureManagerWebAgg.get_javascript()`](https://github.com/mikofski/matplotlib/blob/master/lib/matplotlib/backends/backend_webagg_core.py#L335) calls [`FigureCanvasWebAggCore.get_default_filetype()`](https://github.com/mikofski/matplotlib/blob/master/lib/matplotlib/backends/backend_webagg_core.py#L365) and [`FigureCanvasWebAggCore.get_supported_filetypes_grouped()`](https://github.com/mikofski/matplotlib/blob/master/lib/matplotlib/backends/backend_webagg_core.py#L357) as if they were class methods.
