### PR TITLE
Set focus policy to match Qt, remove outline in webagg

### DIFF
--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -126,7 +126,7 @@ mpl.figure.prototype._init_canvas = function() {
 
     var canvas = $('<canvas/>');
     canvas.addClass('mpl-canvas');
-    canvas.attr('style', "left: 0; top: 0; z-index: 0;")
+    canvas.attr('style', "left: 0; top: 0; z-index: 0; outline: 0")
 
     this.canvas = canvas[0];
     this.context = canvas[0].getContext("2d");
@@ -143,11 +143,6 @@ mpl.figure.prototype._init_canvas = function() {
 
     canvas_div.append(canvas);
     canvas_div.append(rubberband);
-
-    function mouse_out_fn(event) {
-        canvas_div.blur();
-    }
-    canvas_div.on("mouseout", mouse_out_fn);
 
     this.rubberband = rubberband;
     this.rubberband_canvas = rubberband[0];
@@ -170,6 +165,13 @@ mpl.figure.prototype._init_canvas = function() {
     // Set the figure to an initial 600x600px, this will subsequently be updated
     // upon first draw.
     this._resize_canvas(600, 600);
+
+    function set_focus () {
+        canvas.focus();
+        canvas_div.focus();
+    }
+
+    window.setTimeout(set_focus, 100);
 }
 
 mpl.figure.prototype._init_toolbar = function() {
@@ -412,8 +414,9 @@ mpl.findpos = function(e) {
 mpl.figure.prototype.mouse_event = function(event, name) {
     var canvas_pos = mpl.findpos(event)
 
-    if (this.focus_on_mouseover && name === 'motion_notify')
+    if (name === 'button_press')
     {
+        this.canvas.focus();
         this.canvas_div.focus();
     }
 


### PR DESCRIPTION
I realize the timer is a cop-out, but something else was stealing focus after the fact for the `webagg` backend, and it works...