### PR TITLE
Fix issue with clipping of Power Norm

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1171,8 +1171,8 @@ class PowerNorm(Normalize):
             res_mask = result.data < 0
             if clip:
                 mask = ma.getmask(result)
-                val = ma.array(np.clip(result.filled(vmax), vmin, vmax),
-                                mask=mask)
+                result = ma.array(np.clip(result.filled(vmax), vmin, vmax),
+                                  mask=mask)
             resdat = result.data
             resdat -= vmin
             np.power(resdat, gamma, resdat)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -69,6 +69,22 @@ def test_PowerNorm():
     assert_equal(pnorm(a[2]), expected[2])
     assert_array_almost_equal(a[1:], pnorm.inverse(pnorm(a))[1:])
 
+    # Clip = True
+    a = np.array([-0.5, 0, 1, 8, 16], dtype=np.float)
+    expected = [0, 0, 0, 1, 1]
+    pnorm = mcolors.PowerNorm(2, vmin=2, vmax=8, clip=True)
+    assert_array_almost_equal(pnorm(a), expected)
+    assert_equal(pnorm(a[0]), expected[0])
+    assert_equal(pnorm(a[-1]), expected[-1])
+
+    # Clip = True at call time
+    a = np.array([-0.5, 0, 1, 8, 16], dtype=np.float)
+    expected = [0, 0, 0, 1, 1]
+    pnorm = mcolors.PowerNorm(2, vmin=2, vmax=8, clip=False)
+    assert_array_almost_equal(pnorm(a, clip=True), expected)
+    assert_equal(pnorm(a[0], clip=True), expected[0])
+    assert_equal(pnorm(a[-1], clip=True), expected[-1])
+
 
 def test_Normalize():
     norm = mcolors.Normalize()


### PR DESCRIPTION
This should fix the issue that I mentioned in matplotlib/matplotlib#4055 and add tests for it too 