### PR TITLE
TST afm._to_str is now tested against utf8-encoded bytes

### DIFF
--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -1,0 +1,13 @@
+import matplotlib.afm as afm
+import six
+
+
+def test_nonascii_str():
+    # This tests that we also decode bytes as utf-8 properly.
+    # Else, font files with non ascii caracters fail to load.
+
+    if six.PY3:
+        string = "привет".encode("utf8")
+    else:
+        string = "привет"
+    afm._to_str(string)


### PR DESCRIPTION
Here is a small test for the PR.